### PR TITLE
Bugfix: Output JUnit files for multiple devices in xcresult

### DIFF
--- a/lib/fastlane/plugin/xcresult_to_junit/actions/xcresult_to_junit_action.rb
+++ b/lib/fastlane/plugin/xcresult_to_junit/actions/xcresult_to_junit_action.rb
@@ -13,75 +13,78 @@ module Fastlane
 
         devices = result['devices']
         test_plans = result['testNodes']
-        map = {}
-        junit_folder = Helper::XcresultToJunitHelper.save_device_details_to_file(params[:output_path], devices)
-        test_suites = []
 
-        test_plans.each do |test_plan|
-          test_plan['children'].each do |test_bundle|
-            test_bundle['children'].each do |test_suite|
-              suite_name = test_suite['name']
-              count = 0
-              passed = 0
-              failed = 0
-              test_cases = []
-              test_suite['children'].each do |test_case|
-                duration = 0.0
-                duration = test_case['duration'].sub('s', '').to_f if test_case['duration']
-                full_testcase_name = test_case['name'].sub('()', '')
-                tags = full_testcase_name.split('_')[1..]
-                testcase = { name: full_testcase_name, time: duration }
-                count += 1
-                if test_case['result'] == 'Passed'
-                  passed += 1
-                elsif test_case['result'] == 'Failed'
-                  failed += 1
-                  testcase[:failure] ||= []
-                  testcase[:failure_location] ||= []
-                  test_case['children'].each do |failure|
-                    if failure['nodeType'] == 'Repetition'
-                      failure['children'].each do |retry_failure|
-                        testcase[:failure] << retry_failure['name']
-                        testcase[:failure_location] << failure['name']
+        devices.each do |device|
+          map = {}
+          junit_folder = Helper::XcresultToJunitHelper.save_device_details_to_file(params[:output_path], [device])
+          test_suites = []
+
+          test_plans.each do |test_plan|
+            test_plan['children'].each do |test_bundle|
+              test_bundle['children'].each do |test_suite|
+                suite_name = test_suite['name']
+                count = 0
+                passed = 0
+                failed = 0
+                test_cases = []
+                test_suite['children'].each do |test_case|
+                  duration = 0.0
+                  duration = test_case['duration'].sub('s', '').to_f if test_case['duration']
+                  full_testcase_name = test_case['name'].sub('()', '')
+                  tags = full_testcase_name.split('_')[1..]
+                  testcase = { name: full_testcase_name, time: duration }
+                  count += 1
+                  if test_case['result'] == 'Passed'
+                    passed += 1
+                  elsif test_case['result'] == 'Failed'
+                    failed += 1
+                    testcase[:failure] ||= []
+                    testcase[:failure_location] ||= []
+                    test_case['children'].each do |failure|
+                      if failure['nodeType'] == 'Repetition'
+                        failure['children'].each do |retry_failure|
+                          testcase[:failure] << retry_failure['name']
+                          testcase[:failure_location] << failure['name']
+                        end
+                      elsif failure['nodeType'] == 'Failure Message'
+                        testcase[:failure] << failure['name']
+                        testcase[:failure_location] << failure['name'].split(': ')[0]
                       end
-                    elsif failure['nodeType'] == 'Failure Message'
-                      testcase[:failure] << failure['name']
-                      testcase[:failure_location] << failure['name'].split(': ')[0]
                     end
                   end
+                  test_cases << testcase
+                  map["#{suite_name}.#{full_testcase_name}"] = { 'files' => [], 'tags' => tags }
                 end
-                test_cases << testcase
-                map["#{suite_name}.#{full_testcase_name}"] = { 'files' => [], 'tags' => tags }
+                suite = { name: suite_name.to_s, count: count, failures: failed, errors: 0, cases: test_cases }
+                test_suites << suite
               end
-              suite = { name: suite_name.to_s, count: count, failures: failed, errors: 0, cases: test_cases }
-              test_suites << suite
             end
           end
-        end
 
-        Helper::XcresultToJunitHelper.generate_junit(junit_folder, test_suites)
-        attachments_folder = "#{junit_folder}/attachments"
-        Helper::XcresultToJunitHelper.save_attachments(params[:xcresult_path], attachments_folder)
+          Helper::XcresultToJunitHelper.generate_junit(junit_folder, test_suites)
+          attachments_folder = "#{junit_folder}/attachments"
+          Helper::XcresultToJunitHelper.save_attachments(params[:xcresult_path], attachments_folder)
 
-        test_attachments = Helper::XcresultToJunitHelper.fetch_attachment_manifest(attachments_folder)
+          test_attachments = Helper::XcresultToJunitHelper.fetch_attachment_manifest(attachments_folder)
 
-        test_attachments.each do |test_attachment|
-          test_identifier = test_attachment['testIdentifier']
-          folder_name = test_identifier.sub('()', '').sub('/', '.')
+          test_attachments.each do |test_attachment|
+            test_identifier = test_attachment['testIdentifier']
+            folder_name = test_identifier.sub('()', '').sub('/', '.')
 
-          test_attachment['attachments'].reverse().each do |attachment|
-            name = attachment['suggestedHumanReadableName']
-            filename = attachment['exportedFileName']
-            mime_type = 'image/png'
-            mime_type = 'text/plain' if filename.end_with?('.txt')
-            timestamp = attachment['timestamp']
-            map[folder_name] ||= { 'files' => [] }
-            map[folder_name]['files'].push({ 'description' => name, 'mime-type' => mime_type, 'path' => filename,
-                                             'timestamp' => timestamp })
+            test_attachment['attachments'].reverse().each do |attachment|
+              name = attachment['suggestedHumanReadableName']
+              filename = attachment['exportedFileName']
+              mime_type = 'image/png'
+              mime_type = 'text/plain' if filename.end_with?('.txt')
+              timestamp = attachment['timestamp']
+              map[folder_name] ||= { 'files' => [] }
+              map[folder_name]['files'].push({ 'description' => name, 'mime-type' => mime_type, 'path' => filename,
+                                               'timestamp' => timestamp })
+            end
           end
-        end
 
-        Helper::XcresultToJunitHelper.save_screenshot_mapping(map, attachments_folder)
+          Helper::XcresultToJunitHelper.save_screenshot_mapping(map, attachments_folder)
+        end
         UI.message('The xcresult_to_junit plugin has finished!')
       end
 


### PR DESCRIPTION
This PR updates the [fastlane-plugin-xcresult_to_junit] to correctly generate JUnit results for multiple devices found in an xcresult file. Previously, only one device’s results were processed, but now the script loops through all devices and creates a separate JUnit folder for each, including attachments, [device.json], and results.xml. This ensures accurate reporting for parallel or multi-device test runs.

Summary of changes:

Refactored the action to process all devices in the xcresult.
Each device now gets its own output folder with the expected structure.
Verified output: two JUnit folders are generated when two devices are present.
Testing:

Ran the Fastlane lane and confirmed that multiple device results are generated as expected.
